### PR TITLE
[FEATURE] Set custom stremio server IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ In order to use this project, you need to follow these steps:
 8. Switch the DNS settings on your TV back to what they were before
 9. Restart TV
 
+


### PR DESCRIPTION
First of all, this PR is not one per se, it's meant to be an issue, but they are not enable on this fork.

[As per the blogpost](https://blog.stremio.com/installing-stremio-on-hisense-tv/), it's not possible to use any torrent with the hisense app because it doesn't come with the server bundled in, nevertheless, I've found that if the app were to be attach to a server, it works as it should. I ran the [html app](https://wn7lso8ghdka.stremio.com/hisense/1.7.6/) on my PC with a server running in the background.

The problem is that the exemplified setup works because a PC is able to run a server in 127.0.0.1:11470, which is the hardcoded address that the Hisense App uses, if the option to change this IP is added, then the app would be much more feature complete.

![image](https://github.com/user-attachments/assets/9cf1d425-78f9-4825-a8df-48f3cd2da4a9)
> App not able to reach server

![image](https://github.com/user-attachments/assets/12860c09-9a14-41a9-b24e-95648e439a9e)
> App connected to server running on PC